### PR TITLE
(PDK-???) Use shortpaths for PDK base dir

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -116,7 +116,20 @@ module PDK
       raise PDK::CLI::FatalError, _('Package basedir requested for non-package install.') unless package_install?
       require 'pdk/util/version'
 
-      File.dirname(PDK::Util::Version.version_file)
+      dir = File.dirname(PDK::Util::Version.version_file)
+      return dir unless Gem.win_platform?
+
+      begin
+        # Note that the short path detection is not fool-proof.  For example if 8.3 filename creation is disabled
+        # there is no shortname to find. In that case it just returns the long name
+        short_path = PDK::Util::Windows::File.get_short_pathname(dir)
+      rescue RuntimeError => ex
+        # If there are any failures detecting the short path then log a warning and return the, possibly, long path
+        PDK.logger.warn(_("Failed to resolve the shortname of the PDK package directory '%{path}': %{message}") %
+          { path: dir, message: ex.message })
+        return dir
+      end
+      short_path
     end
     module_function :pdk_package_basedir
 

--- a/lib/pdk/util/windows/file.rb
+++ b/lib/pdk/util/windows/file.rb
@@ -1,6 +1,8 @@
 require 'pdk/util/windows'
 
 module PDK::Util::Windows::File
+  #:nocov:
+  # These are wrappers for system level APIs and therefore don't need to be tested
   require 'ffi'
   extend FFI::Library
   extend PDK::Util::Windows::String
@@ -23,6 +25,25 @@ module PDK::Util::Windows::File
   end
   module_function :get_long_pathname
 
+  # Taken from https://github.com/puppetlabs/puppet/blob/ba4d1a1aba0095d3c70b98fea5c67434a4876a61/lib/puppet/util/windows/file.rb
+  def get_short_pathname(path)
+    converted = ''
+    FFI::Pointer.from_string_to_wide_string(path) do |path_ptr|
+      # includes terminating NULL
+      buffer_size = GetShortPathNameW(path_ptr, FFI::Pointer::NULL, 0)
+      FFI::MemoryPointer.new(:wchar, buffer_size) do |converted_ptr|
+        if GetShortPathNameW(path_ptr, converted_ptr, buffer_size) == PDK::Util::Windows::WIN32_FALSE
+          raise _('Failed to call GetShortPathName')
+        end
+
+        converted = converted_ptr.read_wide_string(buffer_size - 1)
+      end
+    end
+
+    converted
+  end
+  module_function :get_short_pathname
+
   ffi_convention :stdcall
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364980(v=vs.85).aspx
@@ -33,4 +54,14 @@ module PDK::Util::Windows::File
   # );
   ffi_lib :kernel32
   attach_function :GetLongPathNameW, [:lpcwstr, :lpwstr, :dword], :dword
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989(v=vs.85).aspx
+  # DWORD WINAPI GetShortPathName(
+  #   _In_  LPCTSTR lpszLongPath,
+  #   _Out_ LPTSTR  lpszShortPath,
+  #   _In_  DWORD   cchBuffer
+  # );
+  ffi_lib :kernel32
+  attach_function_private :GetShortPathNameW, [:lpcwstr, :lpwstr, :dword], :dword
+  #:nocov:
 end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -225,6 +225,12 @@ describe PDK::Util do
     end
 
     context 'when the PDK was installed from a native package', version_file: true do
+      # Note that on Windows, this is not testing the ShortPath conversion as the
+      # path is mocked and the ShortPath API call requires a real on-disk file.  This test
+      # succeeds because if there is an error in the ShortPath detection, it just uses the
+      # long path instead.
+      #
+      # This functionality is exercised properly in the package-testing (acceptance tests)
       it 'returns the directory where the version file is located' do
         is_expected.to eq(File.dirname(version_file))
       end


### PR DESCRIPTION
All child dirs are shortpath safe (no spaces)